### PR TITLE
Create shims for all bundler projects ever rehashed with rbenv-binstubs

### DIFF
--- a/etc/rbenv.d/rehash/rbenv-binstubs.bash
+++ b/etc/rbenv.d/rehash/rbenv-binstubs.bash
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+check_for_binstubs()
+{
+  local root
+  local potential_path
+  if [ "$1" ]; then
+    root="$1"
+  else
+    root="$PWD"
+  fi
+  while [ -n "$root" ]; do
+    if [ -f "$root/Gemfile" ]; then
+      potential_path="$root/bin/$RBENV_COMMAND"
+      if [ -f "$root/.bundle/config" ]; then
+	while read key value 
+	do
+	  case "$key" in
+	  'BUNDLE_BIN:')
+	      case "$value" in
+	      /*)
+		  potential_path="$value/$RBENV_COMMAND"
+		  ;;
+	      *)
+		  potential_path="$root/$value/$RBENV_COMMAND"
+		  ;;
+	      esac
+	      break
+	      ;;
+	  esac
+	done < "$root/.bundle/config"
+      fi
+      if [ -x "$potential_path" ]; then
+	RBENV_COMMAND_PATH="$potential_path"
+      fi
+      break
+    fi
+    root="${root%/*}"
+  done
+}
+
+check_for_bundles ()
+{
+  # go through the list of bundles and run make_shims
+  if [ -f "${RBENV_ROOT}/bundles" ]; then
+    IFS=$'\n'
+    bundles="$(sort -u ${RBENV_ROOT}/bundles)"
+    unset IFS
+    for bundle in $bundles; do
+      check_for_binstubs "$bundle"
+      for shim in $RBENV_COMMAND_PATH/*; do
+        register_shim "${shim##*/}"
+      done
+    done
+    unset IFS
+  fi
+}
+
+add_to_bundles ()
+{
+  local root
+  local potential_path
+  if [ "$1" ]; then
+    root="$1"
+  else
+    root="$PWD"
+  fi
+
+  # add the given path to the list of bundles
+  echo "$root" >> ${RBENV_ROOT}/bundles
+
+  # update the list of bundles to remove any stale ones
+  IFS=$'\n';
+  bundles=$(sort -u ${RBENV_ROOT}/bundles)
+  rm ${RBENV_ROOT}/bundles
+  for bundle in $bundles; do
+    if [ -f "$bundle/Gemfile" ]; then
+      echo "$bundle" >> ${RBENV_ROOT}/bundles
+    fi
+  done
+}
+
+if [ -z "$DISABLE_BINSTUBS" ]; then
+  add_to_bundles
+  check_for_bundles
+fi
+


### PR DESCRIPTION
This patch is a possible solution for issue 5.

It adds a hook to rbenv-rehash to keep track of any bundles in ${RBENV_ROOT}/bundles. The hook does the following:

1) Everytime rehash is run, if the current directory has a Gemfile, it is added to the list of bundles.
2) All installed bundles are checked to see if they have Gemfiles and they are removed from the list if they are no longer present. The check is a simple [ -f "$bundle"/Gemfile ] test, so it shouldn't be long.
3) check_for_binstubs is run on all remaining directories, and a shim is registered for all files in the bin path.

Tests:
1) rbenv which outside of a project path will correctly fail to find the script if it wasn't installed in your ruby version.
2) rbenv which in project 1 finds binstubs for project 1 and rbenv which for project 2 finds binstubs for project 2.

Todo:
1) refactor check_for_binstubs to be in a common include?

I really, really hate typing bundle exec.
