### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,6 @@ Copyright (c) 2013 Ian Heggie - Released under the same terms as [rbenv's MIT-Li
 
 Thanks go to:
 
-* [madumlao](https://github.com/madumlao) - contributed code so this plugin now creates shims for all the executable files in the binstubs directory, thus `bundle --path=vendor/bundle ...` is now handled, as are arbitary executables in the binstubs directory.
+* [madumlao](https://github.com/madumlao) - contributed code so this plugin now creates shims for all the executable files in the binstubs directory, thus `bundle --path=vendor/bundle ...` is now handled, as are arbitrary executables in the binstubs directory.
 * Various people who have given feedback and suggestions via the [issues list](https://github.com/ianheggie/rbenv-binstubs/issues)
 


### PR DESCRIPTION
@ianheggie, I've corrected a typographical error in the documentation of the [rbenv-binstubs](https://github.com/ianheggie/rbenv-binstubs) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.